### PR TITLE
more compact formatting for pretty table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -544,8 +544,8 @@ fn display_with_prettytable(data: &[(Vec<String>, Option<QtyOfUsage>)], filter_f
             } else {
                 row![
                     &column0,
-                    r-> &format!("{} ({:.0}%)", qtys.requested.adjust_scale(), qtys.requested.calc_percentage(&qtys.allocatable)),
-                    r-> &format!("{} ({:.0}%)", qtys.limit.adjust_scale(), qtys.limit.calc_percentage(&qtys.allocatable)),
+                    r-> &format!("({:.0}%) {}", qtys.requested.calc_percentage(&qtys.allocatable), qtys.requested.adjust_scale()),
+                    r-> &format!("({:.0}%) {}", qtys.limit.calc_percentage(&qtys.allocatable), qtys.limit.adjust_scale()),
                     r-> &format!("{}", qtys.allocatable.adjust_scale()),
                     r-> &format!("{}", qtys.calc_free().adjust_scale()),
                 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,7 +507,7 @@ fn display_with_prettytable(data: &[(Vec<String>, Option<QtyOfUsage>)], filter_f
         .padding(1, 1)
         .build();
     table.set_format(format);
-    table.set_titles(row![bl->"Resource", br->"Requested", br->"%Requested", br->"Limit",  br->"%Limit", br->"Allocatable", br->"Free"]);
+    table.set_titles(row![bl->"Resource", br->"Requested", br->"Limit",  br->"Allocatable", br->"Free"]);
     let data2 = data
         .iter()
         .filter(|d| {
@@ -537,19 +537,15 @@ fn display_with_prettytable(data: &[(Vec<String>, Option<QtyOfUsage>)], filter_f
                 Row::new(vec![
                     Cell::new(&column0),
                     Cell::new(&format!("{}", qtys.requested.adjust_scale())).style_spec(style),
-                    Cell::new("").style_spec(style),
                     Cell::new(&format!("{}", qtys.limit.adjust_scale())).style_spec(style),
-                    Cell::new("").style_spec(style),
                     Cell::new("").style_spec(style),
                     Cell::new("").style_spec(style),
                 ])
             } else {
                 row![
                     &column0,
-                    r-> &format!("{}", qtys.requested.adjust_scale()),
-                    r-> &format!("{:4.0}%", qtys.requested.calc_percentage(&qtys.allocatable)),
-                    r-> &format!("{}", qtys.limit.adjust_scale()),
-                    r-> &format!("{:4.0}%", qtys.limit.calc_percentage(&qtys.allocatable)),
+                    r-> &format!("{} ({:.0}%)", qtys.requested.adjust_scale(), qtys.requested.calc_percentage(&qtys.allocatable)),
+                    r-> &format!("{} ({:.0}%)", qtys.limit.adjust_scale(), qtys.limit.calc_percentage(&qtys.allocatable)),
                     r-> &format!("{}", qtys.allocatable.adjust_scale()),
                     r-> &format!("{}", qtys.calc_free().adjust_scale()),
                 ]
@@ -557,8 +553,6 @@ fn display_with_prettytable(data: &[(Vec<String>, Option<QtyOfUsage>)], filter_f
         } else {
             row![
                 &column0,
-                r-> "",
-                r-> "",
                 r-> "",
                 r-> "",
                 r-> "",


### PR DESCRIPTION
I think having an entire column for the percentage is a bit too verbose.  How about adding the percentage as part of the field.

```txt
Resource                                              Requested       Limit  Allocatable     Free 
  cpu                                                  1.2 (10%)   3.1 (26%)         12.0      8.9 
  └─ kind-control-plane                                1.2 (10%)   3.1 (26%)         12.0      8.9 
     ├─ coredns-f9fd979d6-fb9hf                           100.0m         0.0                       
     ├─ coredns-f9fd979d6-sq229                           100.0m         0.0                       
     ├─ kindnet-kzdjk                                     100.0m      100.0m                       
     ├─ kube-apiserver-kind-control-plane                 250.0m         0.0                       
     ├─ kube-controller-manager-kind-control-plane        200.0m         0.0                       
     ├─ kube-scheduler-kind-control-plane                 100.0m         0.0                       
     ├─ pod-a                                             100.0m         1.0                       
     ├─ pod-a2                                            200.0m         1.0                       
     └─ pod-b                                             100.0m         1.0                       
  ephemeral-storage                                     0.0 (0%)    0.0 (0%)      910.2Gi  910.2Gi 
  └─ kind-control-plane                                 0.0 (0%)    0.0 (0%)      910.2Gi  910.2Gi 
  memory                                            490.0Mi (1%)  3.4Gi (5%)       62.7Gi   59.3Gi 
  └─ kind-control-plane                             490.0Mi (1%)  3.4Gi (5%)       62.7Gi   59.3Gi 
     ├─ coredns-f9fd979d6-fb9hf                           70.0Mi     170.0Mi                       
     ├─ coredns-f9fd979d6-sq229                           70.0Mi     170.0Mi                       
     ├─ kindnet-kzdjk                                     50.0Mi      50.0Mi                       
     ├─ pod-a                                            100.0Mi       1.0Gi                       
     ├─ pod-a2                                           100.0Mi       1.0Gi                       
     └─ pod-b                                            100.0Mi       1.0Gi                       
  pods                                                  0.0 (0%)    0.0 (0%)        110.0    110.0 
  └─ kind-control-plane                                 0.0 (0%)    0.0 (0%)        110.0    110.0 
```