### PR TITLE
adding pods as a resource type so they are counted

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,13 @@ fn push_resources(
             location: location.clone(),
         });
     }
+    // add a "pods" resource as well
+    resources.push(Resource {
+        kind: "pods".to_string(),
+        usage: usage.clone(),
+        quantity: Qty::from_str("1")?,
+        location: location.clone(),
+    });
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #99 

This now outputs non-zero values in the last line for pods.

```txt
Resource                                           Requested  %Requested    Limit  %Limit  Allocatable     Free 
  cpu                                                     1.2         10%      3.1     26%         12.0      8.9 
  └─ kind-control-plane                                   1.2         10%      3.1     26%         12.0      8.9 
     ├─ coredns-f9fd979d6-fb9hf                        100.0m                  0.0                               
     ├─ coredns-f9fd979d6-sq229                        100.0m                  0.0                               
     ├─ kindnet-kzdjk                                  100.0m               100.0m                               
     ├─ kube-apiserver-kind-control-plane              250.0m                  0.0                               
     ├─ kube-controller-manager-kind-control-plane     200.0m                  0.0                               
     ├─ kube-scheduler-kind-control-plane              100.0m                  0.0                               
     ├─ pod-a                                          100.0m                  1.0                               
     ├─ pod-a2                                         200.0m                  1.0                               
     └─ pod-b                                          100.0m                  1.0                               
  ephemeral-storage                                       0.0          0%      0.0      0%      910.2Gi  910.2Gi 
  └─ kind-control-plane                                   0.0          0%      0.0      0%      910.2Gi  910.2Gi 
  memory                                              490.0Mi          1%    3.4Gi      5%       62.7Gi   59.3Gi 
  └─ kind-control-plane                               490.0Mi          1%    3.4Gi      5%       62.7Gi   59.3Gi 
     ├─ coredns-f9fd979d6-fb9hf                        70.0Mi              170.0Mi                               
     ├─ coredns-f9fd979d6-sq229                        70.0Mi              170.0Mi                               
     ├─ kindnet-kzdjk                                  50.0Mi               50.0Mi                               
     ├─ pod-a                                         100.0Mi                1.0Gi                               
     ├─ pod-a2                                        100.0Mi                1.0Gi                               
     └─ pod-b                                         100.0Mi                1.0Gi                               
  pods                                                   15.0         14%     15.0     14%        110.0     95.0 
  └─ kind-control-plane                                  15.0         14%     15.0     14%        110.0     95.0 
```

It also works correctly grouping by node and then resource

```txt
Resource               Requested  %Requested  Limit  %Limit  Allocatable     Free 
  kind-control-plane                                                               
  ├─ cpu                      1.2         10%    3.1     26%         12.0      8.9 
  ├─ ephemeral-storage        0.0          0%    0.0      0%      910.2Gi  910.2Gi 
  ├─ memory               490.0Mi          1%  3.4Gi      5%       62.7Gi   59.3Gi 
  └─ pods                    15.0         14%   15.0     14%        110.0     95.0 
```
