### PR TITLE
make library more flexible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,12 +195,12 @@ pub async fn collect_from_nodes(
             context: "list nodes".to_string(),
             source,
         })?;
-    compute_node_utilizations(nodes, resources).await?;
+    extract_allocatable_from_nodes(nodes, resources).await?;
     Ok(())
 }
 
 #[instrument(skip(node_list, resources))]
-pub async fn compute_node_utilizations(
+pub async fn extract_allocatable_from_nodes(
     node_list: ObjectList<Node>,
     resources: &mut Vec<Resource>,
 ) -> Result<(), Error> {
@@ -326,12 +326,12 @@ pub async fn collect_from_pods(
             context: "list pods".to_string(),
             source,
         })?;
-    compute_pod_utilizations(pods, resources).await?;
+    extract_allocatable_from_pods(pods, resources).await?;
     Ok(())
 }
 
 #[instrument(skip(pod_list, resources))]
-pub async fn compute_pod_utilizations(
+pub async fn extract_allocatable_from_pods(
     pod_list: ObjectList<Pod>,
     resources: &mut Vec<Resource>,
 ) -> Result<(), Error> {
@@ -434,12 +434,12 @@ pub async fn collect_from_metrics(
             context: "list podmetrics, maybe Metrics API not available".to_string(),
             source,
         })?;
-    compute_utilizations_metrics(pod_metrics, resources).await?;
+    extract_utilizations_from_pod_metrics(pod_metrics, resources).await?;
     Ok(())
 }
 
 #[instrument(skip(pod_metrics, resources))]
-pub async fn compute_utilizations_metrics(
+pub async fn extract_utilizations_from_pod_metrics(
     pod_metrics: ObjectList<metrics::PodMetrics>,
     resources: &mut Vec<Resource>,
 ) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub fn make_qualifiers(
     out
 }
 
-pub fn make_group_x_qualifier(
+fn make_group_x_qualifier(
     rsrcs: &[&Resource],
     prefix: &[String],
     group_by_fct: &[fn(&Resource) -> Option<String>],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub fn sum_by_qualifier(rsrcs: &[&Resource]) -> Option<QtyByQualifier> {
     }
 }
 
-fn make_qualifiers(
+pub fn make_qualifiers(
     rsrcs: &[Resource],
     group_by: &[GroupBy],
     resource_names: &[String],
@@ -150,7 +150,7 @@ fn make_qualifiers(
     out
 }
 
-fn make_group_x_qualifier(
+pub fn make_group_x_qualifier(
     rsrcs: &[&Resource],
     prefix: &[String],
     group_by_fct: &[fn(&Resource) -> Option<String>],
@@ -195,7 +195,16 @@ pub async fn collect_from_nodes(
             context: "list nodes".to_string(),
             source,
         })?;
-    for node in nodes.items {
+    compute_node_utilizations(nodes, resources).await?;
+    Ok(())
+}
+
+#[instrument(skip(node_list, resources))]
+pub async fn compute_node_utilizations(
+    node_list: ObjectList<Node>,
+    resources: &mut Vec<Resource>,
+) -> Result<(), Error> {
+    for node in node_list.items {
         let location = Location {
             node_name: node.metadata.name,
             ..Location::default()
@@ -317,7 +326,16 @@ pub async fn collect_from_pods(
             context: "list pods".to_string(),
             source,
         })?;
-    for pod in pods.items.into_iter().filter(is_scheduled) {
+    compute_pod_utilizations(pods, resources).await?;
+    Ok(())
+}
+
+#[instrument(skip(pod_list, resources))]
+pub async fn compute_pod_utilizations(
+    pod_list: ObjectList<Pod>,
+    resources: &mut Vec<Resource>,
+) -> Result<(), Error> {
+    for pod in pod_list.items.into_iter().filter(is_scheduled) {
         let spec = pod.spec.as_ref();
         let node_name = spec.and_then(|s| s.node_name.clone());
         let metadata = &pod.metadata;
@@ -416,6 +434,15 @@ pub async fn collect_from_metrics(
             context: "list podmetrics, maybe Metrics API not available".to_string(),
             source,
         })?;
+    compute_utilizations_metrics(pod_metrics, resources).await?;
+    Ok(())
+}
+
+#[instrument(skip(pod_metrics, resources))]
+pub async fn compute_utilizations_metrics(
+    pod_metrics: ObjectList<metrics::PodMetrics>,
+    resources: &mut Vec<Resource>,
+) -> Result<(), Error> {
     let cpu_kind = "cpu";
     let memory_kind = "memory";
     let locations = extract_locations(resources);


### PR DESCRIPTION
This allows to pass pre-processed pod/node list instead passing client directly and IMO is slightly better abstraction

There is another issue with below dependency that makes it impossible to use `` as a lib currently as below uses a feature and conflicts with the feature for `k8s-openapi` defined in the project. I guess a solution could be to define a seperate cargo.toml for the lib and move the feature to the bin only cargo.toml WDYT @davidB ?

`k8s-openapi = { version = "0.11.0", features = ["v1_16"], default-features = false }`