### PR TITLE
fix: stack overflow when format GroupBy tostring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,7 +544,7 @@ impl GroupBy {
 
 impl std::fmt::Display for GroupBy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.to_string())
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
statck overflow when output csv

~$ ./kubectl-view-allocations -o csv

thread 'main' has overflowed its stack
fatal runtime error: stack overflow
Aborted (core dumped)