### PR TITLE
fix: add socks5 support via the kube dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ clap = { version = "4.2", features = ["derive"] }
 color-eyre = "0.6.2"
 itertools = "0.12"
 k8s-openapi = { version = "0.20.0", default-features = false }
-kube = { version = "0.87", features = [
+kube = { version = "0.87.1", features = [
     "client",
     "oauth",
     "gzip",
     "rustls-tls",
+    "socks5",
 ], default-features = false }
 prettytable-rs = { version = "0.10", default-features = false, optional = true }
 serde = "1.0"


### PR DESCRIPTION
Closes #235 