### PR TITLE
feat: add kubectl-view-allocations AI coding skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ kubectl krew install view-allocations
 cargo install kubectl-view-allocations
 ```
 
+### As an AI coding skill
+
+If your AI coding tool supports [skills.sh](https://skills.sh), install the
+`kubectl-view-allocations` skill with:
+
+```sh
+npx skills add davidB/kubectl-view-allocations
+```
+
+This installs the assistant workflow for using `kubectl-view_allocations`; it
+does not install the `kubectl-view-allocations` binary itself.
+
 ### As lib in Cargo.toml
 
 If you want to embed some function or struct of the plugin into an other rust code:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If your AI coding tool supports [skills.sh](https://skills.sh), install the
 npx skills add davidB/kubectl-view-allocations
 ```
 
-This installs the assistant workflow for using `kubectl-view_allocations`; it
+This installs the assistant workflow for using `kubectl view-allocations`; it
 does not install the `kubectl-view-allocations` binary itself.
 
 ### As lib in Cargo.toml

--- a/skills/kubectl-view-allocations/SKILL.md
+++ b/skills/kubectl-view-allocations/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: kubectl-view-allocations
+description: "Use when inspecting Kubernetes resource allocation with kubectl-view_allocations. For allocation questions, use kubectl-view_allocations first and do not replace it with native kubectl get/describe/top/jsonpath queries. Covers cluster/node/namespace/pod requests, limits, allocatable, free capacity, GPU or custom resources, taint-filtered node views, CSV exports, metrics-server utilization via kubectl-view_allocations -u, kubeconfig/context access checks, and allocation-focused troubleshooting. Trigger for CPU, memory, GPU, pod capacity, overcommit, missing requests/limits, tainted nodes, or comparing requested/limit/utilization data in a Kubernetes cluster."
+---
+
+# Kubectl View Allocations
+
+Use `kubectl-view_allocations` as the required first tool for this repository's allocation workflow. Do not answer allocation questions by reconstructing the same data with native `kubectl get`, `kubectl describe`, `kubectl top`, JSONPath, or ad hoc scripts unless `kubectl-view_allocations` cannot run and the user accepts a fallback.
+
+`kubectl-view_allocations` reports Kubernetes allocations from manifests and node allocatable resources; it is not a replacement for `kubectl top`, except when `-u/--utilization` is explicitly requested and Metrics API is available.
+
+## Workflow
+
+1. Clarify scope only when it is missing and risky: kube context, namespace, resource name, node selector, or whether tainted nodes should be included.
+2. Run the first data-gathering query with `kubectl-view_allocations`.
+3. Run a narrow `kubectl-view_allocations` query first, then broaden only if the result looks incomplete.
+4. Prefer allocation views for capacity planning and scheduling questions; use `kubectl-view_allocations -u` only for "currently using" questions.
+5. Explain output in terms of `Requested`, `Limit`, `Allocatable`, and `Free`.
+6. If `kubectl-view_allocations` fails, fix the command invocation path first: installation/PATH, kube context, kubeconfig, permissions, metrics availability, or `--precheck`.
+
+## Tool Policy
+
+- Use `kubectl-view_allocations` for allocation facts and summaries.
+- Use `kubectl` only for narrow support tasks: checking the current context, refreshing auth through `kubectl-view_allocations --precheck`/`kubectl cluster-info`, confirming metrics-server availability after `kubectl-view_allocations -u` fails, or fetching metadata that `kubectl-view_allocations` cannot show and the user explicitly needs.
+- Do not start with `kubectl top` for utilization questions covered by `kubectl-view_allocations -u`.
+- Do not start with `kubectl get nodes/pods -o json` to manually sum requests, limits, allocatable resources, or taints.
+- If `kubectl-view_allocations` is missing, guide the user to install it from the davidB/kubectl-view-allocations README before using fallback allocation commands.
+- If falling back from `kubectl-view_allocations` is unavoidable, tell the user that the fallback is no longer using this skill's primary tool and why.
+
+## Missing Tool
+
+When `kubectl-view_allocations` is not installed or not on PATH:
+
+1. Tell the user the primary tool is missing.
+2. Offer the README-supported install options and ask which they prefer:
+   - krew: `kubectl krew install view-allocations`
+   - cargo: `cargo install kubectl-view-allocations`
+   - release script: `curl https://raw.githubusercontent.com/davidB/kubectl-view-allocations/master/scripts/getLatest.sh | bash`
+3. After installation, run `kubectl-view_allocations --help` or a narrow allocation query to confirm it works.
+4. Do not silently replace the missing tool with native `kubectl` allocation calculations.
+
+## Command Patterns
+
+Use these starting points:
+
+```sh
+kubectl-view_allocations -g resource
+kubectl-view_allocations -g resource,node
+kubectl-view_allocations -g resource,node,pod
+kubectl-view_allocations -g namespace
+kubectl-view_allocations -n NAMESPACE -g resource,node,pod
+kubectl-view_allocations -r cpu,memory -g resource,namespace
+kubectl-view_allocations -r gpu
+kubectl-view_allocations --ignore-taints -g resource,node
+kubectl-view_allocations -u -r cpu,memory
+kubectl-view_allocations -o csv -g resource,node,pod
+```
+
+Add `--context CONTEXT` and `--kubeconfig PATH` when the user names a cluster or config file. Use `--precheck` when kube auth tokens may need refreshing because it runs `kubectl cluster-info` first.
+
+Read `references/command-cookbook.md` for command recipes, interpretation notes, and troubleshooting branches.
+
+## Interpretation
+
+- `Requested`: sum of pod container resource requests from manifests.
+- `Limit`: sum of pod container limits from manifests.
+- `Allocatable`: node allocatable capacity.
+- `Free`: `Allocatable - max(Limit, Requested)` by default; use `--used-mode only-request` to compute free capacity from requests only.
+- `Utilization`: live CPU/memory usage from Metrics API, shown only with `-u`.
+- `__`: value is absent or not meaningful at that grouping level, not necessarily zero.
+
+Default grouping is `resource,node,pod`; `resource` is always prepended when omitted. Default node filtering excludes tainted nodes. Use `--ignore-taints` with no value to include all nodes, or with taint keys/key-value pairs to include specific tainted nodes.
+
+## Safety
+
+Treat `kubectl-view_allocations` as read-only. It lists nodes, pods, and optionally pod metrics. Do not deploy, delete, scale, or modify Kubernetes resources as part of this skill unless the user separately asks for that action.

--- a/skills/kubectl-view-allocations/SKILL.md
+++ b/skills/kubectl-view-allocations/SKILL.md
@@ -1,42 +1,42 @@
 ---
 name: kubectl-view-allocations
-description: "Use when inspecting Kubernetes resource allocation with kubectl-view_allocations. For allocation questions, use kubectl-view_allocations first and do not replace it with native kubectl get/describe/top/jsonpath queries. Covers cluster/node/namespace/pod requests, limits, allocatable, free capacity, GPU or custom resources, taint-filtered node views, CSV exports, metrics-server utilization via kubectl-view_allocations -u, kubeconfig/context access checks, and allocation-focused troubleshooting. Trigger for CPU, memory, GPU, pod capacity, overcommit, missing requests/limits, tainted nodes, or comparing requested/limit/utilization data in a Kubernetes cluster."
+description: "Use when inspecting Kubernetes resource allocation with kubectl view-allocations. For allocation questions, use kubectl view-allocations first and do not replace it with native kubectl get/describe/top/jsonpath queries. Covers cluster/node/namespace/pod requests, limits, allocatable, free capacity, GPU or custom resources, taint-filtered node views, CSV exports, metrics-server utilization via kubectl view-allocations -u, kubeconfig/context access checks, and allocation-focused troubleshooting. Trigger for CPU, memory, GPU, pod capacity, overcommit, missing requests/limits, tainted nodes, or comparing requested/limit/utilization data in a Kubernetes cluster."
 ---
 
 # Kubectl View Allocations
 
-Use `kubectl-view_allocations` as the required first tool for this repository's allocation workflow. Do not answer allocation questions by reconstructing the same data with native `kubectl get`, `kubectl describe`, `kubectl top`, JSONPath, or ad hoc scripts unless `kubectl-view_allocations` cannot run and the user accepts a fallback.
+Use `kubectl view-allocations` as the required first tool for this repository's allocation workflow. Do not answer allocation questions by reconstructing the same data with native `kubectl get`, `kubectl describe`, `kubectl top`, JSONPath, or ad hoc scripts unless `kubectl view-allocations` cannot run and the user accepts a fallback.
 
-`kubectl-view_allocations` reports Kubernetes allocations from manifests and node allocatable resources; it is not a replacement for `kubectl top`, except when `-u/--utilization` is explicitly requested and Metrics API is available.
+`kubectl view-allocations` reports Kubernetes allocations from manifests and node allocatable resources; it is not a replacement for `kubectl top`, except when `-u/--utilization` is explicitly requested and Metrics API is available.
 
 ## Workflow
 
 1. Clarify scope only when it is missing and risky: kube context, namespace, resource name, node selector, or whether tainted nodes should be included.
-2. Run the first data-gathering query with `kubectl-view_allocations`.
-3. Run a narrow `kubectl-view_allocations` query first, then broaden only if the result looks incomplete.
-4. Prefer allocation views for capacity planning and scheduling questions; use `kubectl-view_allocations -u` only for "currently using" questions.
+2. Run the first data-gathering query with `kubectl view-allocations`.
+3. Run a narrow `kubectl view-allocations` query first, then broaden only if the result looks incomplete.
+4. Prefer allocation views for capacity planning and scheduling questions; use `kubectl view-allocations -u` only for "currently using" questions.
 5. Explain output in terms of `Requested`, `Limit`, `Allocatable`, and `Free`.
-6. If `kubectl-view_allocations` fails, fix the command invocation path first: installation/PATH, kube context, kubeconfig, permissions, metrics availability, or `--precheck`.
+6. If `kubectl view-allocations` fails, fix the command invocation path first: installation/PATH, kube context, kubeconfig, permissions, metrics availability, or `--precheck`.
 
 ## Tool Policy
 
-- Use `kubectl-view_allocations` for allocation facts and summaries.
-- Use `kubectl` only for narrow support tasks: checking the current context, refreshing auth through `kubectl-view_allocations --precheck`/`kubectl cluster-info`, confirming metrics-server availability after `kubectl-view_allocations -u` fails, or fetching metadata that `kubectl-view_allocations` cannot show and the user explicitly needs.
-- Do not start with `kubectl top` for utilization questions covered by `kubectl-view_allocations -u`.
+- Use `kubectl view-allocations` for allocation facts and summaries.
+- Use `kubectl` only for narrow support tasks: checking the current context, refreshing auth through `kubectl view-allocations --precheck`/`kubectl cluster-info`, confirming metrics-server availability after `kubectl view-allocations -u` fails, or fetching metadata that `kubectl view-allocations` cannot show and the user explicitly needs.
+- Do not start with `kubectl top` for utilization questions covered by `kubectl view-allocations -u`.
 - Do not start with `kubectl get nodes/pods -o json` to manually sum requests, limits, allocatable resources, or taints.
-- If `kubectl-view_allocations` is missing, guide the user to install it from the davidB/kubectl-view-allocations README before using fallback allocation commands.
-- If falling back from `kubectl-view_allocations` is unavoidable, tell the user that the fallback is no longer using this skill's primary tool and why.
+- If `kubectl view-allocations` is missing, guide the user to install it from the davidB/kubectl-view-allocations README before using fallback allocation commands.
+- If falling back from `kubectl view-allocations` is unavoidable, tell the user that the fallback is no longer using this skill's primary tool and why.
 
 ## Missing Tool
 
-When `kubectl-view_allocations` is not installed or not on PATH:
+When `kubectl view-allocations` is not installed or not on PATH:
 
 1. Tell the user the primary tool is missing.
 2. Offer the README-supported install options and ask which they prefer:
    - krew: `kubectl krew install view-allocations`
    - cargo: `cargo install kubectl-view-allocations`
    - release script: `curl https://raw.githubusercontent.com/davidB/kubectl-view-allocations/master/scripts/getLatest.sh | bash`
-3. After installation, run `kubectl-view_allocations --help` or a narrow allocation query to confirm it works.
+3. After installation, run `kubectl view-allocations --help` or a narrow allocation query to confirm it works.
 4. Do not silently replace the missing tool with native `kubectl` allocation calculations.
 
 ## Command Patterns
@@ -44,16 +44,16 @@ When `kubectl-view_allocations` is not installed or not on PATH:
 Use these starting points:
 
 ```sh
-kubectl-view_allocations -g resource
-kubectl-view_allocations -g resource,node
-kubectl-view_allocations -g resource,node,pod
-kubectl-view_allocations -g namespace
-kubectl-view_allocations -n NAMESPACE -g resource,node,pod
-kubectl-view_allocations -r cpu,memory -g resource,namespace
-kubectl-view_allocations -r gpu
-kubectl-view_allocations --ignore-taints -g resource,node
-kubectl-view_allocations -u -r cpu,memory
-kubectl-view_allocations -o csv -g resource,node,pod
+kubectl view-allocations -g resource
+kubectl view-allocations -g resource,node
+kubectl view-allocations -g resource,node,pod
+kubectl view-allocations -g namespace
+kubectl view-allocations -n NAMESPACE -g resource,node,pod
+kubectl view-allocations -r cpu,memory -g resource,namespace
+kubectl view-allocations -r gpu
+kubectl view-allocations --ignore-taints -g resource,node
+kubectl view-allocations -u -r cpu,memory
+kubectl view-allocations -o csv -g resource,node,pod
 ```
 
 Add `--context CONTEXT` and `--kubeconfig PATH` when the user names a cluster or config file. Use `--precheck` when kube auth tokens may need refreshing because it runs `kubectl cluster-info` first.
@@ -73,4 +73,4 @@ Default grouping is `resource,node,pod`; `resource` is always prepended when omi
 
 ## Safety
 
-Treat `kubectl-view_allocations` as read-only. It lists nodes, pods, and optionally pod metrics. Do not deploy, delete, scale, or modify Kubernetes resources as part of this skill unless the user separately asks for that action.
+Treat `kubectl view-allocations` as read-only. It lists nodes, pods, and optionally pod metrics. Do not deploy, delete, scale, or modify Kubernetes resources as part of this skill unless the user separately asks for that action.

--- a/skills/kubectl-view-allocations/agents/openai.yaml
+++ b/skills/kubectl-view-allocations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kubectl View Allocations"
+  short_description: "Inspect allocations with kubectl-view_allocations"
+  default_prompt: "Use $kubectl-view-allocations to inspect Kubernetes CPU, memory, GPU, pod, and taint-filtered allocations with kubectl-view_allocations."

--- a/skills/kubectl-view-allocations/agents/openai.yaml
+++ b/skills/kubectl-view-allocations/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Kubectl View Allocations"
-  short_description: "Inspect allocations with kubectl-view_allocations"
-  default_prompt: "Use $kubectl-view-allocations to inspect Kubernetes CPU, memory, GPU, pod, and taint-filtered allocations with kubectl-view_allocations."
+c  short_description: "Inspect allocations with kubectl view-allocations"
+  default_prompt: "Use $kubectl-view-allocations to inspect Kubernetes CPU, memory, GPU, pod, and taint-filtered allocations with kubectl view-allocations."

--- a/skills/kubectl-view-allocations/references/command-cookbook.md
+++ b/skills/kubectl-view-allocations/references/command-cookbook.md
@@ -1,68 +1,68 @@
-# kubectl-view_allocations Cookbook
+# kubectl view-allocations Cookbook
 
 ## Primary Command
 
-Use `kubectl-view_allocations` for the first allocation query. Do not substitute `kubectl get`, `kubectl describe`, `kubectl top`, JSONPath, or a custom script for data that `kubectl-view_allocations` already reports. Native `kubectl` is only a support tool for context/auth checks, metrics availability confirmation after `kubectl-view_allocations -u` fails, or metadata that `kubectl-view_allocations` cannot show.
+Use `kubectl view-allocations` for the first allocation query. Do not substitute `kubectl get`, `kubectl describe`, `kubectl top`, JSONPath, or a custom script for data that `kubectl view-allocations` already reports. Native `kubectl` is only a support tool for context/auth checks, metrics availability confirmation after `kubectl view-allocations -u` fails, or metadata that `kubectl view-allocations` cannot show.
 
 ## Quick Recipes
 
 Cluster overview:
 
 ```sh
-kubectl-view_allocations -g resource
+kubectl view-allocations -g resource
 ```
 
 Per-node capacity:
 
 ```sh
-kubectl-view_allocations -g resource,node
+kubectl view-allocations -g resource,node
 ```
 
 Find pods contributing to allocation:
 
 ```sh
-kubectl-view_allocations -g resource,node,pod
+kubectl view-allocations -g resource,node,pod
 ```
 
 Namespace allocation:
 
 ```sh
-kubectl-view_allocations -g resource,namespace
-kubectl-view_allocations -n NAMESPACE -g resource,node,pod
+kubectl view-allocations -g resource,namespace
+kubectl view-allocations -n NAMESPACE -g resource,node,pod
 ```
 
 CPU and memory only:
 
 ```sh
-kubectl-view_allocations -r cpu,memory -g resource,node
+kubectl view-allocations -r cpu,memory -g resource,node
 ```
 
 GPU or extended resource allocation:
 
 ```sh
-kubectl-view_allocations -r gpu
-kubectl-view_allocations -r nvidia.com/gpu -g resource,node,pod
+kubectl view-allocations -r gpu
+kubectl view-allocations -r nvidia.com/gpu -g resource,node,pod
 ```
 
 Include tainted nodes:
 
 ```sh
-kubectl-view_allocations --ignore-taints -g resource,node
-kubectl-view_allocations --ignore-taints node-role.kubernetes.io/control-plane -g resource,node
-kubectl-view_allocations --ignore-taints dedicated=database -g resource,node
+kubectl view-allocations --ignore-taints -g resource,node
+kubectl view-allocations --ignore-taints node-role.kubernetes.io/control-plane -g resource,node
+kubectl view-allocations --ignore-taints dedicated=database -g resource,node
 ```
 
 Live CPU/memory utilization, when metrics-server exists:
 
 ```sh
-kubectl-view_allocations -u -r cpu,memory -g resource,node,pod
+kubectl view-allocations -u -r cpu,memory -g resource,node,pod
 ```
 
 CSV for spreadsheet or script analysis:
 
 ```sh
-kubectl-view_allocations -o csv -g resource,node,pod
-kubectl-view_allocations -o csv -g resource,namespace
+kubectl view-allocations -o csv -g resource,node,pod
+kubectl view-allocations -o csv -g resource,namespace
 ```
 
 ## Choosing Flags
@@ -96,7 +96,7 @@ allocatable - requested
 
 ## Troubleshooting
 
-If `kubectl-view_allocations` is not found, treat the primary tool as missing instead of falling back to native `kubectl` allocation calculations. Tell the user it needs to be installed and ask which README-supported method they want to use:
+If `kubectl view-allocations` is not found, treat the primary tool as missing instead of falling back to native `kubectl` allocation calculations. Tell the user it needs to be installed and ask which README-supported method they want to use:
 
 ```sh
 kubectl krew install view-allocations
@@ -107,15 +107,15 @@ curl https://raw.githubusercontent.com/davidB/kubectl-view-allocations/master/sc
 After installation, verify with:
 
 ```sh
-kubectl-view_allocations --help
+kubectl view-allocations --help
 ```
 
-If tempted to use native `kubectl` to calculate allocation, retry with a different `kubectl-view_allocations` grouping/filter first. For example, use `kubectl-view_allocations -g resource,node,pod`, `kubectl-view_allocations -g resource,namespace`, `kubectl-view_allocations -r cpu,memory`, `kubectl-view_allocations -r gpu`, or `kubectl-view_allocations --ignore-taints` before falling back.
+If tempted to use native `kubectl` to calculate allocation, retry with a different `kubectl view-allocations` grouping/filter first. For example, use `kubectl view-allocations -g resource,node,pod`, `kubectl view-allocations -g resource,namespace`, `kubectl view-allocations -r cpu,memory`, `kubectl view-allocations -r gpu`, or `kubectl view-allocations --ignore-taints` before falling back.
 
 If authentication looks stale, retry with:
 
 ```sh
-kubectl-view_allocations --precheck
+kubectl view-allocations --precheck
 ```
 
 If results miss control-plane or dedicated nodes, remember that the default excludes tainted nodes. Retry with `--ignore-taints` or a specific taint key/key-value.

--- a/skills/kubectl-view-allocations/references/command-cookbook.md
+++ b/skills/kubectl-view-allocations/references/command-cookbook.md
@@ -1,0 +1,127 @@
+# kubectl-view_allocations Cookbook
+
+## Primary Command
+
+Use `kubectl-view_allocations` for the first allocation query. Do not substitute `kubectl get`, `kubectl describe`, `kubectl top`, JSONPath, or a custom script for data that `kubectl-view_allocations` already reports. Native `kubectl` is only a support tool for context/auth checks, metrics availability confirmation after `kubectl-view_allocations -u` fails, or metadata that `kubectl-view_allocations` cannot show.
+
+## Quick Recipes
+
+Cluster overview:
+
+```sh
+kubectl-view_allocations -g resource
+```
+
+Per-node capacity:
+
+```sh
+kubectl-view_allocations -g resource,node
+```
+
+Find pods contributing to allocation:
+
+```sh
+kubectl-view_allocations -g resource,node,pod
+```
+
+Namespace allocation:
+
+```sh
+kubectl-view_allocations -g resource,namespace
+kubectl-view_allocations -n NAMESPACE -g resource,node,pod
+```
+
+CPU and memory only:
+
+```sh
+kubectl-view_allocations -r cpu,memory -g resource,node
+```
+
+GPU or extended resource allocation:
+
+```sh
+kubectl-view_allocations -r gpu
+kubectl-view_allocations -r nvidia.com/gpu -g resource,node,pod
+```
+
+Include tainted nodes:
+
+```sh
+kubectl-view_allocations --ignore-taints -g resource,node
+kubectl-view_allocations --ignore-taints node-role.kubernetes.io/control-plane -g resource,node
+kubectl-view_allocations --ignore-taints dedicated=database -g resource,node
+```
+
+Live CPU/memory utilization, when metrics-server exists:
+
+```sh
+kubectl-view_allocations -u -r cpu,memory -g resource,node,pod
+```
+
+CSV for spreadsheet or script analysis:
+
+```sh
+kubectl-view_allocations -o csv -g resource,node,pod
+kubectl-view_allocations -o csv -g resource,namespace
+```
+
+## Choosing Flags
+
+- Use `-r/--resource-name` for resource filters. Matching is substring-based, so `-r gpu` can match `nvidia.com/gpu`.
+- Use `-n/--namespace` one or more times, or comma-separated, for pod namespace filtering.
+- Use `-l/--selector` to filter nodes by label selector.
+- Use `-z/--show-zero` to expose zero-request/zero-limit rows and pods with unset CPU/memory requests and limits.
+- Use `--used-mode only-request` when the scheduling question should ignore limits and focus on requested resources.
+- Use `--accept-invalid-certs` only when the user explicitly accepts that risk.
+
+## Output Semantics
+
+`Requested` and `Limit` come from pod manifests. Regular containers are summed. Init container resources use max semantics. Pod overhead is added to both requests and limits. A synthetic `pods` resource is counted as 1 per scheduled pod.
+
+Only scheduled pods are included. Succeeded and Failed pods are excluded. Pending pods are included only when the PodScheduled condition is true. Pods on nodes excluded by taint or selector filtering are not counted.
+
+`Free` defaults to:
+
+```text
+allocatable - max(limit, requested)
+```
+
+It floors at zero. With `--used-mode only-request`, it becomes:
+
+```text
+allocatable - requested
+```
+
+`Utilization` is available only for CPU and memory and only when `-u` can list PodMetrics. If Metrics API lookup fails, the table falls back to allocation-only output.
+
+## Troubleshooting
+
+If `kubectl-view_allocations` is not found, treat the primary tool as missing instead of falling back to native `kubectl` allocation calculations. Tell the user it needs to be installed and ask which README-supported method they want to use:
+
+```sh
+kubectl krew install view-allocations
+cargo install kubectl-view-allocations
+curl https://raw.githubusercontent.com/davidB/kubectl-view-allocations/master/scripts/getLatest.sh | bash
+```
+
+After installation, verify with:
+
+```sh
+kubectl-view_allocations --help
+```
+
+If tempted to use native `kubectl` to calculate allocation, retry with a different `kubectl-view_allocations` grouping/filter first. For example, use `kubectl-view_allocations -g resource,node,pod`, `kubectl-view_allocations -g resource,namespace`, `kubectl-view_allocations -r cpu,memory`, `kubectl-view_allocations -r gpu`, or `kubectl-view_allocations --ignore-taints` before falling back.
+
+If authentication looks stale, retry with:
+
+```sh
+kubectl-view_allocations --precheck
+```
+
+If results miss control-plane or dedicated nodes, remember that the default excludes tainted nodes. Retry with `--ignore-taints` or a specific taint key/key-value.
+
+If `-u` shows no utilization, verify metrics-server/PodMetrics availability. Do not treat missing utilization as zero usage.
+
+If namespaces look empty, verify the namespace filter and RBAC permissions. The command needs to list nodes, pods, and optionally pod metrics.
+
+If CSV headers look surprising, note that `Kind` identifies the current grouping level and group columns follow the selected `-g` order.


### PR DESCRIPTION
## Summary
- add a kubectl-view-allocations AI coding skill for allocation-focused Kubernetes troubleshooting
- include command recipes and interpretation guidance for common CPU, memory, GPU, namespace, node, taint, CSV, and utilization workflows
- document installation with `npx skills add davidB/kubectl-view-allocations` in the README

## Testing
- not run; skill and documentation-only change